### PR TITLE
http-hotfix: adds hotfix for urls without protocol

### DIFF
--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -2,6 +2,16 @@ class Url < ApplicationRecord
   validates_presence_of :url, :access
   scope :top, ->(limit) { order('access desc').limit(limit) }
 
+  before_validation :normalize_url, on: :create
+    # check if url is valid and/or it has a scheme
+
+  def normalize_url
+    u = URI.parse(self.url)
+    if(!u.scheme)
+      self.url = "http://#{self.url}"
+    end
+  end
+
   def self.process_url(url)
     u = Url.create(url: url)
     u.minified_url = "#{ENV.fetch('SHORT_URL_PROTOCOL')}://#{ENV.fetch('SHORT_URL_HOSTNAME')}/y/#{EncodingUrlService.instance.bijective_encode(u.id)}"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -17,7 +17,6 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu/xenial64'
 
   config.vm.box = 'ubuntu/xenial64'
-  config.vm.provision 'shell', path: './scripts/ruby.sh', privileged: false
   config.vm.provision 'shell', path: './scripts/postgresql.sh', privileged: true
   config.vm.provision 'shell', path: './scripts/utils.sh', privileged: false
   config.vm.provision 'shell', path: './scripts/redis.sh', privileged: false

--- a/vagrant/scripts/redis.sh
+++ b/vagrant/scripts/redis.sh
@@ -1,4 +1,4 @@
-cd /tmp
+pushd /tmp
 curl -O http://download.redis.io/redis-stable.tar.gz
 tar xzvf redis-stable.tar.gz
 cd redis-stable
@@ -17,3 +17,7 @@ sudo chmod 770 /var/lib/redis
 sudo systemctl start redis
 sudo systemctl status redis
 echo config set stop-writes-on-bgsave-error no | redis-cli
+sudo systemctl stop redis
+sudo systemctl start redis
+sudo systemctl status redis
+popd


### PR DESCRIPTION
## Why we need this hotfix?

Fixes cases like when you try to minify i.e `zombo.com`, this algorithm requires always a full http address to redirect, so we use an active record callback to detect if no http/s is used, we add it prior insertion.